### PR TITLE
Change vec reference to slice reference

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -18,7 +18,7 @@ pub struct CharSet {
 }
 
 impl CharSet {
-    pub fn new(chars: &Vec<usize>) -> CharSet {
+    pub fn new(chars: &[usize]) -> CharSet {
         let mut contained = vec![false; chars.len()];
         let mut count = 0;
         for i in 0..chars.len() {


### PR DESCRIPTION
It is unnecessary to take an immutable reference to a `Vec` because it can coerce into a slice.